### PR TITLE
Added guidance for esri-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Try the next version at https://js.arcgis.com/next or with npm using `npm instal
 Or, if you're using [esri-loader](https://github.com/Esri/esri-loader) to help load the library, you can specify this url as [an option](https://github.com/Esri/esri-loader#from-a-specific-version):
 ```javascript
 const [Map] = await loadModules(['esri/map'], {url: 'https://js.arcgis.com/next'});
+```
 
 ## TypeScript Typings
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ To read all about the current version of the JavaScript API at https://developer
 
 Try the next version at https://js.arcgis.com/next or with npm using `npm install --save arcgis-js-api@next`.
 
+Note, if you're using [esri-loader](https://github.com/Esri/esri-loader) to help load the library, you can specify this url as [an option](https://github.com/Esri/esri-loader#from-a-specific-version):
+```javascript
+const [Map] = await loadModules(['esri/map'], {url: 'https://js.arcgis.com/next'});
+```
+
 ## Issues
 
 Report issues with next version at https://github.com/Esri/feedback-js-api-next/issues/new/choose


### PR DESCRIPTION
This repository is awesome!

Many people use `esri-loader` to fetch the API, so quickly added two lines on using the next release in that environment. 