### PR TITLE
add note for webpack plugin next

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ You can use the typings included with `arcgis-js-api@next` two ways.
 }
 ```
 
+## Using Webpack
+
+If you are using `arcgis-js-api@next` in a webpack application, you will also need to install the `next` version of the [`@arcgis/webpack-plugin`](https://github.com/Esri/arcgis-webpack-plugin).
+
+```sh
+npm install --save-dev @arcgis/webpack-plugin@next
+```
+
 ## Issues
 
 Report issues with next version at https://github.com/Esri/feedback-js-api-next/issues/new/choose


### PR DESCRIPTION
This PR adds a note for the `next` build for upcoming 4.16. Once 4.16 is released, we can tentatively remove this note.