### PR TITLE
Remove ES modules beta overview page.

### DIFF
--- a/ES_modules.md
+++ b/ES_modules.md
@@ -1,7 +1,0 @@
-## ES modules
-
-As of 4.18, the ES modules (beta) build of the ArcGIS API for JavaScript is now available on NPM: [`npm install @arcgis/core`](https://www.npmjs.com/package/@arcgis/core).
-
-For more information, visit the [Build with ES modules](http://developers.esri.com/javascript/latest/guide/es-modules/) Guide page.
-
-There are also [sample applications](https://github.com/Esri/jsapi-resources/tree/master/esm-samples) available for various popular frameworks, module bundlers and build tools.


### PR DESCRIPTION
HOLD merging until 4.19 release. 

cc @dasa 