### PR TITLE
Update deprecations list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The following are deprecated and will be removed in a future release. For anythi
 <details>
   <summary>Click to expand!</summary>  
 
+* Compatibility with implementations that don't support [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#async_and_await) at runtime, within AMD modules, is deprecated since version 4.25. For example, Angular applications using [esri-loader](https://github.com/Esri/esri-loader) will need to migrate from AMD modules to using [@arcgis/core ES modules](https://developers.arcgis.com/javascript/latest/es-modules/).
 * BasemapToggle.toggle deprecated since version 4.22. Watch the activeBasemap property instead.
 * CreateWorkflow deprecated since version 4.23. Use CreateFeaturesWorkflow instead.
 * CreateWorkflowData.edits deprecated since 4.23. Use CreateFeaturesWorkflow.pendingFeatures to access edits made to the workflow data.


### PR DESCRIPTION
Async/await support at runtime for the APIs AMD modules will be required. For example, this may affect Angular apps using esri-loader.

@dasa this is pretty much a mirror copy of the release notes.