### PR TITLE
Add view popup migration and breaking changes to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ const expandWidget = new Expand({
 ### View Popup deprecations and changes
 In a continuous effort to optimize the performance of the API, more specifically the load time, the decision was made to stop bundling the Popup with the MapView and SceneView. The Popup widget receives new features regularly, such as when browsing related records. Each new feature added to the popup widget increases the amount of built code and size of the widget that is being sent to the web browser. For example, the Popup module, which is bundled with the MapView, represents around 50% of the size of the bundle.
 
-In this release, the Popup widget loading is deferred until the view is ready and will only be loaded if there are layers with a popup configured since it is only useful once content is displayed on the view. Please expand the details below for breaking changes and the migration strategy.
+In this release, the Popup widget loading is deferred until the view is ready and finished updating, and will only be loaded if View.popupEnabled is true. Please expand the details below for breaking changes and the migration strategy.
 
 TODO: Add code examples.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ TODO: Add code examples.
 
 If using any of the following scenarios, your application will **not** break:
   
-#### Setting popup options:
+#### Setting popup options
 ```js
 const view = new MapView({
   popup: {
@@ -43,7 +43,7 @@ const view = new MapView({
 view.popup.dockEnabled = true;
 ```
 
-#### Opening & closing the popup:
+#### Opening & closing the popup
 - It is recommended to use the new `View.openPopup()` method instead of `view.popup.open()`, however, it will still work.
 ```js
 // prompts a deprecation warning if popup isn't created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ view.popup.autoOpenEnabled = true;
 view.popupEnabled = true;
 ```
 
-### Breaks and require immediate attention
+### Breaks and requires immediate attention
 
 Using functions other than `open` and `close`, like `watch`. Use `reactiveUtils` instead.
 ```js
@@ -165,7 +165,7 @@ view.popupEnabled = false;
 
 ## Breaking Changes
 
-* TBD
+* The Popup widget loading is deferred until the view is ready and finished updating, and will only be loaded if View.popupEnabled is true. Expand the details in the [View Popup deprecations and changes](#view-popup-deprecations-and-changes) section above for more details on breaking changes and the migration strategy.
 
 The following classes, methods, properties and events have been deprecated for at least 2 releases and have now been removed from the SDK:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ In a continuous effort to optimize the performance of the API, more specifically
 
 In this release, the Popup widget loading is deferred until the view is ready and will only be loaded if there are layers with a popup configured since it is only useful once content is displayed on the view. Please expand the details below for breaking changes and the migration strategy.
 
+TODO: Add code examples.
+
 <details>
   <summary>Click to expand the details regarding the migration strategy and breaking changes for the view's popup</summary>  
 
@@ -273,5 +275,3 @@ The following are deprecations to the SDK's TypeScript type definitions, and wil
 - Instances of `*Constructor` deprecated since 4.25. Update usage of `__esri.ModuleConstructor` to `typeof __esri.Module`, or `import` the module from typings and change the type assignment to `typeof Module`.
 
 </details>
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ const expandWidget = new Expand({
 ```
 
 ### View Popup deprecations and changes
-In a continuous effort to optimize the performance of the API, more specifically the load time, the decision was made to stop bundling the Popup with the MapView and SceneView. The Popup widget receives new features regularly, such as when browsing related records. Each new feature added to the popup widget increases the amount of built code and size of the widget that is being sent to the web browser. For example, the Popup module, which is bundled with the MapView, represents around 50% of the size of the bundle.
+In a continuous effort to optimize the performance and load time of the API, the Popup widget will no longer be bundled with the MapView and SceneView. The Popup widget receives new features regularly, such as when browsing related records. Each new feature added to the Popup widget increases the size of the widget and amount of built code that is sent to the web browser. For example, the Popup module, which is bundled with the MapView, represents around 50% of the size of the bundle.
 
 In this release, the Popup widget loading is deferred until the view is ready and finished updating, and will only be loaded if View.popupEnabled is true. Please expand the details below for breaking changes and the migration strategy.
 
@@ -31,7 +31,7 @@ TODO: Add code examples.
 
 ### Scenarios that still work
 
-If using any of the following scenarios, your applcation will not break:
+If using any of the following scenarios, your application will **not** break:
   
 #### Setting popup options:
 ```js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,148 @@ const expandWidget = new Expand({
 })
 ```
 
+### View Popup deprecations and changes
+In a continuous effort to optimize the performance of the API, more specifically the load time, the decision was made to stop bundling the Popup with the MapView and SceneView. The Popup widget receives new features regularly, such as when browsing related records. Each new feature added to the popup widget increases the amount of built code and size of the widget that is being sent to the web browser. For example, the Popup module, which is bundled with the MapView, represents around 50% of the size of the bundle.
+
+In this release, the Popup widget loading is deferred until the view is ready and will only be loaded if there are layers with a popup configured since it is only useful once content is displayed on the view. Please expand the details below for breaking changes and the migration strategy.
+
+<details>
+  <summary>Click to expand the details regarding the migration strategy and breaking changes for the view's popup</summary>  
+
+### Scenarios that still work
+
+If using any of the following scenarios, your applcation will not break:
+  
+#### Setting popup options:
+```js
+const view = new MapView({
+  popup: {
+    dockEnabled: true
+  }
+});
+view.popup.dockEnabled = true;
+```
+
+#### Opening & closing the popup:
+- It is recommended to use the new `View.openPopup()` method instead of `view.popup.open()`, however, it will still work.
+```js
+// prompts a deprecation warning if popup isn't created
+// calls view.openPopup() under the hood
+view.popup.open(...);
+
+// new
+view.openPopup(...);
+```
+- It is recommended to use the new `View.closePopup()` method instead of `view.popup.close()`, however, it will still work.
+```js
+// prompts a deprecation warning if popup isn't created
+// calls view.closePopup() under the hood
+view.popup.close(...);
+
+// new
+view.closePopup();
+```
+
+#### Disable the view's popup
+```js
+// autoOpenEnabled deprecated
+view.popup.autoOpenEnabled = true;
+
+// new
+view.popupEnabled = true;
+```
+
+### Breaks and require immediate attention
+
+Using functions other than `open` and `close`, like `watch`. Use `reactiveUtils` instead.
+```js
+// old - will break
+view.popup.watch("selectedFeature", ...)
+
+// new
+reactiveUtils.watch(() => view.popup?.selectedFeature, ...);
+```
+
+Modifying properties that don't exist anymore.
+```js
+// old - will break
+view.popup.actions.push(...)
+
+// or define the property with the actions
+view.popup.actions = [ ... ]
+// new: or wait for the popup
+reactiveUtils.whenOnce(() => view.popup.actions != null);
+view.popup.actions.push(...)
+```
+
+Same as above, `viewModel` doesn't exist.
+
+```js
+// old - will break
+get active() {
+  return view.popup.viewModel.active;
+}
+
+// new
+get active() {
+  return view.popup?.viewModel?.active ?? false;
+}
+```
+
+### Migration Strategy
+
+#### When do you have to migrate, and what to do?
+
+1. If the application creates a `Popup` instance, no changes are necessary. This is also **the fastest migration strategy**, and equivalent to the 4.26 behavior.
+
+```js
+const view = new SceneView({
+  popup: new Popup(...)
+});
+```
+
+2. If the application accesses properties of the view model, use conditionally access.
+
+```js
+view.popup.viewModel.active;
+// becomes
+view.popup?.viewModel?.active;
+```
+
+3. If the application uses `view.popup.open()` or `close()`, search and replace with `view.openPopup()` and `view.closePopup()`.
+
+4. If the application is only setting options on the popup, no changes are necessary.
+
+```js
+const view = new MapView({
+  popup: {
+    dockEnabled: true.
+    dockPosition: ....
+  }
+})
+```
+
+### Configuring the `Popup`
+
+There are multiple ways to configure the popup:
+
+```js
+// popup shows for features and other use such as Search results.
+// view.popup is available immediately
+view.popup = new Popup() 
+        
+//  popup shows for features and other use such as Search results.
+// view.popup is created on demand when the user clicks on the view, or when `openPopup()` is called the first time.
+view.popup = { /*...*/ };
+
+// popup is completely disabled and won't show on features, Search results, and `openPopup()`.
+view.popup = null;
+
+// popup doesn't show for features on click, but will on Search results and `openPopup()`.
+view.popupEnabled = false;
+```
+</details>
+
 ## Breaking Changes
 
 * TBD
@@ -40,14 +182,7 @@ Please refer to the [Breaking changes](https://developers.arcgis.com/javascript/
 
 ## Deprecations
 
-The following are deprecated and will be removed in a future release. For anything deprecated in 4.25 and earlier, additional information and links are in the [release notes](https://developers.arcgis.com/javascript/latest/release-notes/#deprecated-classes-properties-methods-events).
-
-### View Popup autocasting deprecation
-In a continuous effort to optimize the performance of the API, more specifically the load time, the decision was made to stop bundling the Popup with the MapView and SceneView. The Popup widget receives new features regularly, such as when browsing related records. Each new feature added to the popup widget increases the amount of built code and size of the widget that is being sent to the web browser. For example, the Popup module, which is bundled with the MapView, represents around 50% of the size of the bundle.
-
-In a future release, the Popup widget loading will be deferred until the view is ready and will only be loaded if there are layers with a popup configured since it is only useful once content is displayed on the view. This will not disturb the user experience and the popup will still show up when the end user clicks on popup enabled content.
-
-If you are interested in testing this optimization, make sure to check back here for the early access release description, where we will provide more details and strategies to upgrade your code as we get closer to the next release.
+The following are deprecated and will be removed in a future release. For anything deprecated in 4.26 and earlier, additional information and links are in the [release notes](https://developers.arcgis.com/javascript/latest/release-notes/#deprecated-classes-properties-methods-events).
 
 <details>
   <summary>Click to expand the complete list</summary>  
@@ -96,6 +231,7 @@ If you are interested in testing this optimization, make sure to check back here
 - InputFieldGroup.visibilityExpression deprecated Since 4.23. Use groupElement.visibilityExpression
 Lighting deprecated since version 4.24. Use SunLighting instead.
 - PausableWatchHandle.PausableWatchHandle deprecated since version 4.24.
+- Popup.autoOpenEnabled deprecated since 4.27. Use MapView/SceneView.popupEnabled instead.
 - PromisedWatchHandle.PromisedWatchHandle deprecated since version 4.24. Use Promise instead.
 promiseUtils.create deprecated since version 4.24. Use Promise instead.
 - The allowAttachments property within Editor.layerInfos is deprecated at 4.25. Use either attachmentsOnCreateEnabled or attachmentsOnUpdateEnabled instead.
@@ -137,3 +273,5 @@ The following are deprecations to the SDK's TypeScript type definitions, and wil
 - Instances of `*Constructor` deprecated since 4.25. Update usage of `__esri.ModuleConstructor` to `typeof __esri.Module`, or `import` the module from typings and change the type assignment to `typeof Module`.
 
 </details>
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,24 +142,32 @@ const view = new MapView({
 })
 ```
 
-### Configuring the `Popup`
-
-There are multiple ways to configure the popup:
-
+### Setting the View's `Popup`
+Since the Popup is no longer loaded with the view automatically, there are now different ways to set the view's popup:
+- Set the view's popup to a new `Popup` instance to have the popup created right away. When doing this, the popup will appear for all scenarios such as selecting feartures and displaying Search results:
 ```js
-// popup shows for features and other use such as Search results.
 // view.popup is available immediately
-view.popup = new Popup() 
-        
+view.popup = new Popup();
+```
+- Set the view's popup to an object that contains `Popup` properties such as `dockEnabled` and `dockOptions`. In this case, the view's popup is created on demand when the user clicks the view or when `openPopup()` is called for the first time and not when the application is first loaded.
+```js
 //  popup shows for features and other use such as Search results.
-// view.popup is created on demand when the user clicks on the view, or when `openPopup()` is called the first time.
-view.popup = { /*...*/ };
-
+view.popup = {
+  dockEnabled: true,
+  dockOptions: {
+    ...
+  }
+};
+```
+- Set the view's popup to `null`. This will disable the `Popup` for every scenario for your application. Use this when you never want to show any popups.
+```js
 // popup is completely disabled and won't show on features, Search results, and `openPopup()`.
 view.popup = null;
-
+```
+- Set the view's `popupEnabled` property to false. This will not create a popup until `openPopup()` is called or when Search results need to be displayed.
+```js
 // popup doesn't show for features on click, but will on Search results and `openPopup()`.
-view.popupEnabled = false;
+`view.popupEnabled = false;
 ```
 </details>
 


### PR DESCRIPTION
This PR adds information regarding the view popup changes that may cause apps to break. It details out what people need to do to migrate if they have breaking changes. Once the functionality is installed (currently targeted for Tuesday 4/11), I will add some codepen examples to showcase the changes and this PR can be merged so customers can test the functionality.

@ycabon @bsvensson @annelfitz could you please review the content and once this is approved, I can add some examples and merge next week? Thanks!