### PR TITLE
doc(changelog): add ES5 class utility support deprecation note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,7 @@ The following are deprecated and will be removed in a future release. For anythi
 <details>
   <summary>Click to expand the complete list</summary>  
 
-- Compatibility with implementations that don't support async/await at runtime, within AMD modules, is deprecated since version 4.25. For example, Angular applications using esri-loader will need to migrate from AMD modules to using @arcgis/core ES modules.
+- Compatibility with ES5 class utilities is deprecated for AMD builds, and will be removed at 4.28. For example, this will remove the ability to use Dojo to interact with the SDKs classes using Dojo's `declare` and `lang` modules.
 - CreateWorkflow deprecated since version 4.23. Use CreateFeaturesWorkflow instead.
 - CreateWorkflowData.edits deprecated since 4.23. Use CreateFeaturesWorkflow.pendingFeatures to access edits made to the workflow data.
 - CreateWorkflowData deprecated since version 4.23. Use CreateFeaturesWorkflowData instead.


### PR DESCRIPTION
Also removed old/duplicate note async/await support being required in AMD modules at runtime. 