### PR TITLE
docs(changelog): deprecation notice for the AMD npm package `arcgis-js-api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,8 @@ Please refer to the [Breaking changes](https://developers.arcgis.com/javascript/
 
 The following are deprecated and will be removed in a future release. For anything deprecated in 4.28 and earlier, additional information and links are in the [release notes](https://developers.arcgis.com/javascript/latest/release-notes/#deprecated-classes-properties-methods-events).
 
-- The [`esri-loader`](https://github.com/Esri/esri-loader/blob/master/README.md) library is deprecated at version 4.29. Use [components](https://developers.arcgis.com/javascript/latest/components/) or the [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules instead.
+- The AMD npm package [`arcgis-js-api`](https://www.npmjs.com/package/arcgis-js-api) is deprecated at version 4.29. This is related to dropping local build support for legacy Dojo 1 and RequireJS. Use [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules or plan on moving to [components (beta)](https://developers.arcgis.com/javascript/latest/components/) instead.
+- The [`esri-loader`](https://github.com/Esri/esri-loader/blob/master/README.md) library is deprecated at version 4.29. Use [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules or plan on moving to [components (beta)](https://developers.arcgis.com/javascript/latest/components/) instead.
 
 <details>
   <summary>Click to expand the complete list</summary>

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ More information is available in the SDK's [Build with ES modules](https://next.
 
 ## TypeScript typings for ES modules
 
-Typings are included with the npm install of ES modules. For most use cases, no special TypeScript configurations are required.
+Typings are included with the npm install of `@arcgis/core`. For most use cases, no special TypeScript configurations are required.
 
-## TypeScript typings for AMD modules
+## TypeScript typings for AMD modules (deprecated)
 
-The typings are also included with the npm install of AMD modules, and they can be used in two ways.
+The typings for use with AMD modules in local builds are deprecated since 4.29. They are included with the install of the npm package [`arcgis-js-api`](https://www.npmjs.com/package/arcgis-js-api), and can be used in two ways.
 
 ### Include a `///` directive in your main TypeScript file.
 
@@ -83,7 +83,7 @@ const [Map] = await loadModules(['esri/map'], options);
 
 ## Licensing
 
-Copyright 2023 Esri
+Copyright 2024 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the CHANGELOG and README. 