### PR TITLE
chore: sync version shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArcGIS Maps SDK for JavaScript - next
 
-![Current build version](https://img.shields.io/npm/v/arcgis-js-api/next?label=Current%20build)
+![Current build version](https://img.shields.io/npm/v/@arcgis/core/next?label=Current%20build)
 
 **https://js.arcgis.com/next**
 


### PR DESCRIPTION
Sync the README and CHANGELOG version shields.  We switched to using @arcgis/core. I missed this on my previous PR.