### PR TITLE
docs(changelog): update AMD npm breaking change wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The `next` version of 4.31 is now available. Planned release date is October 202
 
 # Breaking Changes
 
-- The AMD npm package [`arcgis-js-api`](https://www.npmjs.com/package/arcgis-js-api) will be retired at 4.31. This is related to dropping local build support for legacy Dojo 1 and RequireJS. Use [components](https://developers.arcgis.com/javascript/latest/components/) or [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules instead.
+- Version 4.31 is the last release of the AMD npm package [`arcgis-js-api`](https://www.npmjs.com/package/arcgis-js-api). Use components or the @arcgis/core ES modules package, instead. See the [Get started with npm](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide topic for more information.
 - The npm package [`@arcgis/cli`](https://www.npmjs.com/package/@arcgis/cli) will be retired at 4.31. Use [components](https://developers.arcgis.com/javascript/latest/components/) and Calcite.
 - The [`esri-loader`](https://github.com/Esri/esri-loader/blob/master/README.md) library will be retired at 4.31. Use [components](https://developers.arcgis.com/javascript/latest/components/) or [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules instead.
 


### PR DESCRIPTION
Clarify that the last release of the `arcgis-js-api` (AMD) package on npm is 4.31. This does not affect the AMD CDN, components or @arcgis/core. 